### PR TITLE
Qualify reagent dependency name

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src/cljs"]
  :deps  {org.clojure/clojurescript {:mvn/version "1.10.773"}
-         reagent                   {:mvn/version "1.1.0"}
+         reagent/reagent           {:mvn/version "1.1.0"}
          cljsjs/codemirror         {:mvn/version "5.44.0-1"}}}


### PR DESCRIPTION
I noticed that Figwheel will display a warning whenever bringing in this library as a dep, because the reagent dep name was not qualified. This tiny PR should rectify that.